### PR TITLE
Add issue template config enabling blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []


### PR DESCRIPTION
Add .github/ISSUE_TEMPLATE/config.yml to enable opening blank issues (blank_issues_enabled: true) and initialize contact_links as an empty array so users can create generic issues without selecting a template.