### PR TITLE
Set default titles for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_review.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_review.yml
@@ -1,6 +1,6 @@
 name: Documentation Review Task
 description: Review documentation for brokers, APIs, or software packages.
-title: ""
+title: "[Docs]: "
 labels:
   - sprint
   - documentation

--- a/.github/ISSUE_TEMPLATE/project_initialization.yml
+++ b/.github/ISSUE_TEMPLATE/project_initialization.yml
@@ -1,6 +1,6 @@
 name: Microlensing Sprint Project Proposal
 description: Propose a new project or work package for the Microlensing Sprint.
-title: " "
+title: "[Project]: "
 labels:
   - sprint
   - microlensing


### PR DESCRIPTION
Prefill issue template titles: add "[Docs]: " to .github/ISSUE_TEMPLATE/documentation_review.yml and "[Project]: " to .github/ISSUE_TEMPLATE/project_initialization.yml. This ensures new issues use consistent title prefixes for documentation and project proposals.